### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,16 @@ Add to section doctrine - dbal in **config.yml** option **driver_class**
             driver:         %database_driver%
             driver_class:   \Realestate\MssqlBundle\Driver\PDODblib\Driver
 
+make sure your %database_driver% is set to pdo_dblib
+
+*************************
+In app/AppKernel.php registerBundles(), add the following line:
+   $bundles = array(
+            ...
+            new Realestate\MssqlBundle\RealestateMssqlBundle(),
+    ...
+    );
+
 *************************
 In Doctrine\DBAL\DriverManager's $_driverMap property, add this driver to the list:
 


### PR DESCRIPTION
I forgot to add the entry in AppKernel and the DateTime override was not loaded. Had problem fetching datetime (not datetime2) field from db.

also, I think it would be good to specify that pdo_dblib must be set for the %database_driver% variable in parameters.ini
